### PR TITLE
append error middlewares when route is added

### DIFF
--- a/Sources/express/Route.swift
+++ b/Sources/express/Route.swift
@@ -106,6 +106,7 @@ open class Route: MiddlewareObject, RouteKeeper {
   
   public func add(route: Route) {
     self.middleware.append(route.middleware)
+    self.errorMiddleware.append(contentsOf: route.errorMiddleware)
   }
 
   // MARK: MiddlewareObject


### PR DESCRIPTION
First off I want to say this is an awesome project, I'm a iOS dev that has used Express for some of my personal backend projects. Seeing Express in the type-safe Swift world is amazing.  

I'm currently using MacroExpress to create a simple mock server, however, I was having an issue with error handling. 

**The problem:** 
When throwing an error from a middleware or calling a middleware's next callback with an error, the error is never propagated to any error handlers.

**To reproduce:**
```swift 
enum ExampleError: Error {
    case foo
}

let app = Express()

let errorHandler: ErrorMiddleware = { (error, req, res, next) in
    // Never gets called
    print("called error handler with error: \(error)")
}

app.use(errorHandler)

app.get("/foo1") { (req, res, next) in
    throw ExampleError.foo
}

app.get("/foo2") { (req, res, next) in
    next(ExampleError.foo)
}

app.listen(1337) {
    print("server started")
}
```

Any requests to /foo1 or /foo2 will return a 404 and the Xcode console will print out the following message: 

> warning μ.console : No middleware called end: <Express: #routes=3 engines=mustache,html 'view engine'='mustache'> GET /foo1


**The fix:**
I tracked the problem down to the Route.swift file where a new route is added. In the add function the normal middlewares are added but the errorMiddlewares are not added. To fix I just appended the errorMiddlewares and everything worked as expected. I haven't done a deep dive into the implications of this change but it got things working for me:

```swift 
self.errorMiddleware.append(contentsOf: route.errorMiddleware)
```


