### PR TITLE
Fix special case where "/" would match with all paths

### DIFF
--- a/Sources/express/RoutePattern.swift
+++ b/Sources/express/RoutePattern.swift
@@ -142,6 +142,10 @@ public enum RoutePattern {
       }
     }
     
+    // I don't know if this special case is the best way to handle this but there was a one off error where
+    // any routes that use "/" for the pattern would match all routes
+    if case .root  = pattern[0], pattern.count == 1 && escapedPathComponents.count > 1 { return nil }
+    
     // there have to be more or the same number of components in the path like
     // things to match in the pattern ...
     guard escapedPathComponents.count >= pattern.count else { return nil }


### PR DESCRIPTION
I noticed that if I put my "/" route first that it would match with all paths, so I had to list it as the last path in order for anything to work. I am not sure if adding another special case rule is the *best* way to fix but it does seem to do the job. This causes MacroExpress to now match the behavior of exress.js in the same situation.